### PR TITLE
dumping github reponse to json a roundabout way

### DIFF
--- a/Hook/ext.py
+++ b/Hook/ext.py
@@ -10,6 +10,7 @@ import re
 import hmac
 import hashlib
 import json
+import sys
 
 from Hook.models import model_maker
 
@@ -805,7 +806,8 @@ class HookUI(object):
 
         if user is None:
             # Make a call to the API
-            more = self.api.get("user", params={"access_token": access_token}).json()
+            resp = json.dumps(self.api.get("user", params={"access_token": access_token}))
+            more = json.loads(resp)
             kwargs = dict(git_id=more["id"], login=more["login"])
             if "email" in more:
                 kwargs["email"] = more["email"]


### PR DESCRIPTION
possibly a 3.6-3.5 compatibility issue?

Not sure if it's the python version or something else but without this change I got this error:

```
[Fri Apr 14 12:01:29.302069 2017] [wsgi:error] [pid 4400:tid 140382082049792] [remote 72.224.22.205:44870]   File "/usr/local/hook/Hook/ext.py", line 808, in authorize
[Fri Apr 14 12:01:29.302071 2017] [wsgi:error] [pid 4400:tid 140382082049792] [remote 72.224.22.205:44870]     more = self.api.get("user", params={"access_token": access_token}).json()
[Fri Apr 14 12:01:29.302081 2017] [wsgi:error] [pid 4400:tid 140382082049792] [remote 72.224.22.205:44870] AttributeError: 'dict' object has no attribute 'json'
```